### PR TITLE
chore: dockerize project and integrate frontend with backend

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,12 +1,13 @@
-# Copie para .env e ajuste conforme necessário
 POSTGRES_DB=lunetras
 POSTGRES_USER=lunetras
 POSTGRES_PASSWORD=lunetras
 POSTGRES_PORT=5432
 
-BACKEND_IMAGE=lunetras-backend:latest
 BACKEND_PORT=8080
-SPRING_PROFILES_ACTIVE=docker
-
 FRONTEND_PORT=4173
+
+SPRING_PROFILES_ACTIVE=docker
+SPRING_JPA_HIBERNATE_DDL_AUTO=update
+APP_CORS_ALLOWED_ORIGINS=http://localhost:4173
+
 VITE_API_URL=http://localhost:8080

--- a/LUNETRAS-BACK/.dockerignore
+++ b/LUNETRAS-BACK/.dockerignore
@@ -1,5 +1,4 @@
-node_modules
-dist
+target
 .git
 .gitignore
 .idea

--- a/LUNETRAS-BACK/Dockerfile
+++ b/LUNETRAS-BACK/Dockerfile
@@ -1,0 +1,13 @@
+FROM maven:3.9.9-eclipse-temurin-17 AS build
+WORKDIR /app
+
+COPY pom.xml ./
+COPY src ./src
+RUN mvn -B -DskipTests clean package
+
+FROM eclipse-temurin:17-jre-alpine AS runtime
+WORKDIR /app
+
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/LUNETRAS-BACK/src/main/java/com/lunetras/config/SecurityConfig.java
+++ b/LUNETRAS-BACK/src/main/java/com/lunetras/config/SecurityConfig.java
@@ -1,17 +1,27 @@
 package com.lunetras.config;
 
 import com.lunetras.service.UsuarioDetailsService;
-import org.springframework.context.annotation.*;
-import org.springframework.security.authentication.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
     private final UsuarioDetailsService usuarioDetailsService;
+
+    @Value("${app.cors.allowed-origins:http://localhost:4173}")
+    private String allowedOrigins;
 
     public SecurityConfig(UsuarioDetailsService usuarioDetailsService) {
         this.usuarioDetailsService = usuarioDetailsService;
@@ -22,6 +32,8 @@ public class SecurityConfig {
 
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> {
+                })
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
                         .anyRequest().authenticated()
@@ -34,5 +46,25 @@ public class SecurityConfig {
                 );
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        List<String> origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isEmpty())
+                .toList();
+
+        configuration.setAllowedOrigins(origins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
     }
 }

--- a/LUNETRAS-BACK/src/main/resources/application.properties
+++ b/LUNETRAS-BACK/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=lunetras
+
+app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:4173}

--- a/README.md
+++ b/README.md
@@ -202,33 +202,42 @@ O **LUNETRAS** é uma solução educacional que une tecnologia e pedagogia, cont
 
 ## Execução com Docker (qualquer máquina)
 
-Para evitar dependência de caminhos locais de Java (ex.: `java.home` no VS Code), a execução pode ser feita totalmente por containers.
+Esta configuração sobe o banco PostgreSQL, o back-end Spring Boot e o front-end React em containers integrados.
 
-### Arquivos adicionados
+### Arquivos de Docker
 
-- `docker-compose.yml`: sobe banco PostgreSQL, back-end e front-end.
-- `Dockerfile.backend`: imagem padrão para API Spring Boot (Java 17 + Maven).
+- `docker-compose.yml`: orquestra banco, API e front-end.
+- `LUNETRAS-BACK/Dockerfile`: build e runtime da API Java 17.
 - `LUNETRAS_Front/Dockerfile`: build do React/Vite e publicação via Nginx.
-- `.env.docker.example`: variáveis de ambiente de referência.
+- `.env.docker.example`: variáveis de ambiente padrão para desenvolvimento local.
 
-### 1) Subir todo o ambiente
+### 1) Configurar ambiente
 
 ```bash
 cp .env.docker.example .env
+```
+
+### 2) Subir tudo
+
+```bash
 docker compose up -d --build
 ```
 
-Front-end: `http://localhost:4173`  
-Back-end: `http://localhost:8080`
+### 3) Acessos
 
-### 2) Build da imagem do back-end
+- Front-end: `http://localhost:4173`
+- Back-end: `http://localhost:8080`
+- Banco PostgreSQL: `localhost:5432`
 
-No repositório do back-end (Spring Boot), use o `Dockerfile.backend` como base:
+### 4) Parar ambiente
 
 ```bash
-docker build -f Dockerfile.backend -t lunetras-backend:latest .
+docker compose down
 ```
 
-Depois, volte a este repositório e rode o `docker compose up -d`.
+Para remover também o volume do banco:
 
-> Observação: o serviço `backend` no compose usa a imagem `lunetras-backend:latest` por padrão (configurável em `BACKEND_IMAGE`).
+```bash
+docker compose down -v
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,20 +11,31 @@ services:
       - '${POSTGRES_PORT:-5432}:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-lunetras} -d ${POSTGRES_DB:-lunetras}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     networks:
       - lunetras-net
 
   backend:
+    build:
+      context: ./LUNETRAS-BACK
+      dockerfile: Dockerfile
     image: ${BACKEND_IMAGE:-lunetras-backend:latest}
     container_name: lunetras-backend
     restart: unless-stopped
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/${POSTGRES_DB:-lunetras}
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-lunetras}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-lunetras}
+      SPRING_JPA_HIBERNATE_DDL_AUTO: ${SPRING_JPA_HIBERNATE_DDL_AUTO:-update}
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-docker}
+      APP_CORS_ALLOWED_ORIGINS: ${APP_CORS_ALLOWED_ORIGINS:-http://localhost:4173}
     ports:
       - '${BACKEND_PORT:-8080}:8080'
     networks:


### PR DESCRIPTION
### Motivation
- Provide a reproducible local development stack using Docker to run PostgreSQL, the Spring Boot API and the React frontend together. 
- Allow the frontend to call the backend from containers by enabling configurable CORS and environment-driven URLs. 
- Simplify building and packaging of the Java API with a multi-stage Dockerfile and reduce noise during image builds with `.dockerignore` files.

### Description
- Added `LUNETRAS-BACK/Dockerfile` (multi-stage Maven build + JRE runtime) and `LUNETRAS-BACK/.dockerignore` to build and package the backend as a containerized JAR. 
- Updated `docker-compose.yml` to build the backend image from `LUNETRAS-BACK`, added a PostgreSQL `healthcheck`, configured `depends_on` to wait for DB health, and injected datasource/CORS/JPA environment variables. 
- Implemented CORS configuration in the backend by updating `LUNETRAS-BACK/src/main/java/com/lunetras/config/SecurityConfig.java` and exposing `app.cors.allowed-origins` in `LUNETRAS-BACK/src/main/resources/application.properties`. 
- Added and updated environment example `/.env.docker.example`, improved `LUNETRAS_Front/.dockerignore`, and updated `README.md` with Docker setup and usage instructions. 

### Testing
- Successfully built the frontend with `cd LUNETRAS_Front && npm run build` (build completed). 
- `docker compose config` could not be executed in the environment because the `docker` command is not available. 
- Backend compile attempt with Maven (`cd LUNETRAS-BACK && mvn -DskipTests compile`) failed due to the project parent POM `org.springframework.boot:spring-boot-starter-parent:4.0.3` not being resolvable from the environment's Maven central (network / repository restrictions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a777768704832487fc91a54c9dc9ee)