### PR TITLE
Renomear scripts de banco para lunetras-bd e movê-los para LUNETRAS-BD

### DIFF
--- a/LUNETRAS-BD/lunetras-bd-schema.sql
+++ b/LUNETRAS-BD/lunetras-bd-schema.sql
@@ -1,0 +1,84 @@
+-- LUNETRAS - Schema PostgreSQL alinhado ao domínio atual do backend
+
+CREATE TABLE IF NOT EXISTS usuarios (
+    id BIGSERIAL PRIMARY KEY,
+    nome VARCHAR(255),
+    email VARCHAR(255) NOT NULL UNIQUE,
+    senha VARCHAR(255),
+    perfil VARCHAR(30) NOT NULL CHECK (perfil IN ('ADMIN', 'PROFESSOR')),
+    ativo BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE IF NOT EXISTS turmas (
+    id BIGSERIAL PRIMARY KEY,
+    nome VARCHAR(255) NOT NULL,
+    ano INTEGER NOT NULL CHECK (ano BETWEEN 1 AND 5),
+    professor_id BIGINT,
+    CONSTRAINT fk_turma_professor
+      FOREIGN KEY (professor_id)
+      REFERENCES usuarios (id)
+      ON DELETE SET NULL,
+    CONSTRAINT uq_turma_nome_ano UNIQUE (nome, ano)
+);
+
+CREATE TABLE IF NOT EXISTS professor_turma (
+    professor_id BIGINT NOT NULL,
+    turma_id BIGINT NOT NULL,
+    PRIMARY KEY (professor_id, turma_id),
+    CONSTRAINT fk_professor_turma_professor
+      FOREIGN KEY (professor_id)
+      REFERENCES usuarios (id)
+      ON DELETE CASCADE,
+    CONSTRAINT fk_professor_turma_turma
+      FOREIGN KEY (turma_id)
+      REFERENCES turmas (id)
+      ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS alunos (
+    id BIGSERIAL PRIMARY KEY,
+    nome VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    data_nascimento DATE,
+    turma_id BIGINT,
+    CONSTRAINT fk_aluno_turma
+      FOREIGN KEY (turma_id)
+      REFERENCES turmas (id)
+      ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS avaliacoes_psicogeneticas (
+    id BIGSERIAL PRIMARY KEY,
+    bimestre INTEGER NOT NULL CHECK (bimestre BETWEEN 1 AND 4),
+    nivel VARCHAR(60) NOT NULL CHECK (
+      nivel IN (
+        'ICONICA',
+        'GARATUJA',
+        'PRE_SILABICO',
+        'SILABICO_SEM_VALOR_SONORO',
+        'SILABICO_COM_VALOR_SONORO',
+        'ALFABETICO',
+        'ORTOGRAFICO'
+      )
+    ),
+    observacoes TEXT,
+    data_avaliacao DATE NOT NULL,
+    periodo_letivo INTEGER NOT NULL,
+    aluno_id BIGINT NOT NULL,
+    professor_id BIGINT NOT NULL,
+    CONSTRAINT fk_avaliacao_aluno
+      FOREIGN KEY (aluno_id)
+      REFERENCES alunos (id)
+      ON DELETE CASCADE,
+    CONSTRAINT fk_avaliacao_professor
+      FOREIGN KEY (professor_id)
+      REFERENCES usuarios (id)
+      ON DELETE RESTRICT,
+    -- regra de negócio mais próxima da implementação atual (1 avaliação por aluno+bimestre)
+    CONSTRAINT uq_avaliacao_aluno_bimestre UNIQUE (aluno_id, bimestre)
+);
+
+CREATE INDEX IF NOT EXISTS idx_turmas_professor_id ON turmas (professor_id);
+CREATE INDEX IF NOT EXISTS idx_alunos_turma_id ON alunos (turma_id);
+CREATE INDEX IF NOT EXISTS idx_avaliacoes_aluno_id ON avaliacoes_psicogeneticas (aluno_id);
+CREATE INDEX IF NOT EXISTS idx_avaliacoes_professor_id ON avaliacoes_psicogeneticas (professor_id);

--- a/LUNETRAS-BD/lunetras-bd-seed.sql
+++ b/LUNETRAS-BD/lunetras-bd-seed.sql
@@ -1,0 +1,34 @@
+-- Seeds iniciais para ambiente local (idempotente)
+-- senha em BCrypt para "admin123"
+INSERT INTO usuarios (nome, email, senha, perfil, ativo)
+VALUES (
+  'Administrador LUNETRAS',
+  'admin@lunetras.local',
+  '$2a$10$Q8hC6Q0QhQf6s8pNf7KJ0OS8YxM7f7xwTzQhcsKtB9Q3l4J8kT6xm',
+  'ADMIN',
+  TRUE
+)
+ON CONFLICT (email) DO NOTHING;
+
+-- senha em BCrypt para "prof123"
+INSERT INTO usuarios (nome, email, senha, perfil, ativo)
+VALUES (
+  'Professor(a) Demo',
+  'professor@lunetras.local',
+  '$2a$10$Q8hC6Q0QhQf6s8pNf7KJ0OS8YxM7f7xwTzQhcsKtB9Q3l4J8kT6xm',
+  'PROFESSOR',
+  TRUE
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO turmas (nome, ano, professor_id)
+SELECT '1º Ano A', 1, u.id
+FROM usuarios u
+WHERE u.email = 'professor@lunetras.local'
+ON CONFLICT (nome, ano) DO NOTHING;
+
+INSERT INTO alunos (nome, email, data_nascimento, turma_id)
+SELECT 'Aluno Demo', 'aluno.demo@lunetras.local', '2018-03-15', t.id
+FROM turmas t
+WHERE t.nome = '1º Ano A' AND t.ano = 1
+ON CONFLICT (email) DO NOTHING;

--- a/README.md
+++ b/README.md
@@ -229,6 +229,21 @@ docker compose up -d --build
 - Back-end: `http://localhost:8080`
 - Banco PostgreSQL: `localhost:5432`
 
+### Banco inicial (schema + seed)
+
+Ao subir o `db` pela primeira vez, o PostgreSQL executa automaticamente os scripts em `LUNETRAS-BD/`:
+
+- `lunetras-bd-schema.sql`: cria tabelas, chaves estrangeiras, checks e índices alinhados às entidades do backend.
+- `lunetras-bd-seed.sql`: cria usuários e dados iniciais para desenvolvimento local.
+
+> Importante: esses scripts rodam apenas na inicialização de um volume novo do banco.
+> Para reaplicar do zero, remova o volume do PostgreSQL e suba novamente o ambiente.
+
+```bash
+docker compose down -v
+docker compose up -d --build
+```
+
 ### 4) Parar ambiente
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - '${POSTGRES_PORT:-5432}:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./LUNETRAS-BD:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-lunetras} -d ${POSTGRES_DB:-lunetras}"]
       interval: 5s


### PR DESCRIPTION
### Motivation

- Atender à solicitação de organizar os scripts SQL em uma pasta dedicada e padronizar os nomes conforme convenção do projeto.

### Description

- Mudei os scripts de `database/postgresql/` para a nova pasta `LUNETRAS-BD/` e renomeei-os para `lunetras-bd-schema.sql` e `lunetras-bd-seed.sql`.
- Atualizei o `docker-compose.yml` para montar `./LUNETRAS-BD` em `/docker-entrypoint-initdb.d` para que o Postgres execute os scripts na inicialização de um volume novo.
- Ajustei o `README.md` para referenciar a nova pasta e os novos nomes dos arquivos e adicionei instruções curtas sobre reaplicar o schema/seed.

### Testing

- Verifiquei que não restaram referências antigas com `rg -n "database/postgresql|01_schema|02_seed|LUNETRAS-BD|lunetras-bd" -g '!**/node_modules/**'` e a busca retornou os caminhos atualizados com sucesso.
- Inspecionei o início dos arquivos movidos com `nl -ba LUNETRAS-BD/lunetras-bd-schema.sql | sed -n '1,20p'` e `nl -ba LUNETRAS-BD/lunetras-bd-seed.sql | sed -n '1,20p'` para confirmar o conteúdo esperado.
- Confirmei a alteração do `docker-compose.yml` com uma leitura parcial (`nl -ba docker-compose.yml | sed -n '1,30p'`) para validar a montagem da nova pasta; todas as verificações automatizadas retornaram sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9c1748474832493aed7fcaba0876b)